### PR TITLE
Fixes typo that made makeTable crash

### DIFF
--- a/index.js
+++ b/index.js
@@ -173,7 +173,7 @@ module.exports.table = table
 function table(data, opts) {
   if (opts.templateID) {
     var templateID = opts.templateID
-  } else var templateID = opts.targetDiv.replace("#", "")
+  } else var templateID = opts.tableDiv.replace("#", "")
   var tableContents = ich[templateID]({
     rows: data
   })


### PR DESCRIPTION
I was trying out the examples, but makeTable didn't work. Figured out that there was a typo in the [May 9th update](https://github.com/jlord/sheetsee-tables/commit/f36d53cb053c14e4060b75b75ab7f501c5dd3c94). [Screenshot with some info](http://i.imgur.com/NHTnASl.png).

ps: paper trail, [original pull](https://github.com/jlord/sheetsee.js/pull/49) I (should not have :D) made in the sheetsee.js repo
pps: loving sheetsee, hope to contribute an example soon
