### PR TITLE
Add step-by-step table setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ If you want to have an input to allow users to search/filter the data in the tab
 
 ```javascript
 <input id="tableFilter" type="text" placeholder="filter by.."></input>
-<a href="#" class=".clear">Clear</a>
+<a href="#" class="clear">Clear</a>
 ```
 
 Then you'll pass your `tableOptions` object into this method:
@@ -99,18 +99,18 @@ Sheetsee.initiateTableFilter(tableOptions)
 _HTML_
 
 ```HTML
-<input id="siteTableFilter" type="text"></input><a href="#" class=".clear">Clear</a>
+<input id="siteTableFilter" type="text"></input><a href="#" class="clear">Clear</a>
 <div id="siteTable"></div>
 ```
 
 _Template_
 
 ```JavaScript
-<script id="tableTemplate" type="text/html">
+<script id="siteTable_template" type="text/html">
     <table>
     <tr><th class="tHeader">City</th><th class="tHeader">Place Name</th><th class="tHeader">Year</th><th class="tHeader">Image</th></tr>
       {{#rows}}
-        <tr><td>{{city}}</td><td>{{placename}}</td><td>{{year}}</td><td>{{image}}</td></tr>
+        <tr><td>{{City}}</td><td>{{PlaceName}}</td><td>{{Year}}</td><td>{{Image}}</td></tr>
       {{/rows}}
   </table>
 </script>
@@ -133,6 +133,10 @@ _JavaScript_
   })
 </script>
 ```
+
+## Step-by-step table setup
+
+See [docs/table-setup.md](docs/table-setup.md) for a complete walkthrough that starts with spreadsheet-shaped data, adds the required HTML placeholder, builds the Mustache template, enables sorting and filtering, and includes a small troubleshooting checklist for common demo problems.
 
 _[View Demo](http://jlord.us/sheetsee.js/demos/demo-table.html)_
 _[Visit Site](http://jlord.us/sheetsee.js)_

--- a/README.md
+++ b/README.md
@@ -6,6 +6,17 @@ Sheetsee,js uses this module to make tables. With this module you can create tab
 
 You'll need a placeholder `<div>` in your html, a `<script>` with a [Mustache.js](https://mustache.github.io) template and a `<script>` that tells Sheetsee to build the table.
 
+## Quick start
+
+Build the bundled local demo and open `test/index.html` in a browser:
+
+```bash
+npm install
+npm run bfy
+```
+
+The demo uses `test/data.js`, `test/index.html`, and the generated `test/sheetsee.js` bundle. Use it as the quickest working reference for placeholder ids, template ids, sorting headers, filtering, and pagination.
+
 ## Your HTML Placeholder
 
 This is as simple as an empty `<div>` with an `id`.
@@ -138,5 +149,5 @@ _JavaScript_
 
 See [docs/table-setup.md](docs/table-setup.md) for a complete walkthrough that starts with spreadsheet-shaped data, adds the required HTML placeholder, builds the Mustache template, enables sorting and filtering, and includes a small troubleshooting checklist for common demo problems.
 
-_[View Demo](http://jlord.us/sheetsee.js/demos/demo-table.html)_
+_[View local demo](test/index.html)_
 _[Visit Site](http://jlord.us/sheetsee.js)_

--- a/docs/table-setup.md
+++ b/docs/table-setup.md
@@ -93,6 +93,14 @@ Then open `test/index.html` in a browser and confirm:
 - Clicking `Clear` empties the filter input and restores the table.
 - Pagination links move between pages when enough rows are present.
 
+For a simple static server instead of opening the file directly, run one from the project root and visit the test page:
+
+```bash
+python -m http.server 8765
+```
+
+Then open `http://127.0.0.1:8765/test/index.html`.
+
 ## Troubleshooting
 
 - If the table area is empty, check that `tableDiv` points to an existing element id.

--- a/docs/table-setup.md
+++ b/docs/table-setup.md
@@ -1,0 +1,101 @@
+# Step-by-step table setup
+
+This guide shows the smallest working path from spreadsheet-shaped data to a sortable, filterable Sheetsee table.
+
+## 1. Prepare the data
+
+Sheetsee expects an array of objects. Each object is one row and each object key is a spreadsheet column name.
+
+```javascript
+var data = [
+  { City: 'Oakland', PlaceName: 'Lake Merritt', Year: '2017', Image: 'lake.jpg' },
+  { City: 'Detroit', PlaceName: 'Eastern Market', Year: '2019', Image: 'market.jpg' }
+]
+```
+
+Keep the object keys stable. Sorting removes spaces and punctuation from the table header text, so a header such as `Place Name` maps to the `PlaceName` data key.
+
+## 2. Add the filter and table placeholder
+
+Add an optional filter input, a clear link with the `clear` class, and an empty div for the table.
+
+```html
+<input id="siteTableFilter" type="text" placeholder="filter by...">
+<a href="#" class="clear">Clear</a>
+<div id="siteTable"></div>
+```
+
+The table placeholder id is used again in the JavaScript options.
+
+## 3. Add the Mustache template
+
+The template id should match the table placeholder id plus `_template`. For `#siteTable`, the default template id is `siteTable_template`.
+
+```html
+<script id="siteTable_template" type="text/html">
+  <table>
+    <tr>
+      <th class="tHeader">City</th>
+      <th class="tHeader">Place Name</th>
+      <th class="tHeader">Year</th>
+      <th class="tHeader">Image</th>
+    </tr>
+    {{#rows}}
+      <tr>
+        <td>{{City}}</td>
+        <td>{{PlaceName}}</td>
+        <td>{{Year}}</td>
+        <td>{{Image}}</td>
+      </tr>
+    {{/rows}}
+  </table>
+</script>
+```
+
+Headers with the `tHeader` class can be clicked to sort. The rendered values use the exact data keys from step 1.
+
+## 4. Build the table
+
+Pass the same data and element ids into `Sheetsee.makeTable`. Then enable filtering with `Sheetsee.initiateTableFilter`.
+
+```html
+<script>
+  document.addEventListener('DOMContentLoaded', function () {
+    var tableOptions = {
+      data: data,
+      pagination: 10,
+      tableDiv: '#siteTable',
+      filterDiv: '#siteTableFilter'
+    }
+
+    Sheetsee.makeTable(tableOptions)
+    Sheetsee.initiateTableFilter(tableOptions)
+  })
+</script>
+```
+
+`templateID` is optional when your template follows the `tableDiv + "_template"` naming convention. Add it only when you want to use a different template id.
+
+## 5. Check the demo
+
+Run the bundled test demo locally:
+
+```bash
+npm install
+npm run bfy
+```
+
+Then open `test/index.html` in a browser and confirm:
+
+- The table renders rows from `test/data.js`.
+- Clicking a `tHeader` table header changes sort order.
+- Typing into the filter input narrows the rows.
+- Clicking `Clear` empties the filter input and restores the table.
+- Pagination links move between pages when enough rows are present.
+
+## Troubleshooting
+
+- If the table area is empty, check that `tableDiv` points to an existing element id.
+- If the template is not found, either use `tableDiv` plus `_template` or pass `templateID`.
+- If sort does nothing, make sure headers use `class="tHeader"` and their text maps to a data key after spaces and punctuation are removed.
+- If clear does nothing, use `class="clear"` rather than `class=".clear"`.

--- a/test/browserify.js
+++ b/test/browserify.js
@@ -1,6 +1,7 @@
 var fs = require('fs')
 var browserify = require('browserify')
+var path = require('path')
 
-browserify(__dirname + '/set.js')
+browserify(path.join(__dirname, 'set.js'))
   .bundle()
-  .pipe(fs.createWriteStream(__dirname + '/sheetsee.js'))
+  .pipe(fs.createWriteStream(path.join(__dirname, 'sheetsee.js')))

--- a/test/data.js
+++ b/test/data.js
@@ -1,27 +1,27 @@
-var data = [
- {
-  "Animal": "Cat",
-  "Name": "Liza",
-  "Rating": "10"
- },
- {
-  "Animal": "Dog",
-  "Name": "Boo",
-  "Rating": "9"
- },
- {
-  "Animal": "Dog",
-  "Name": "Sam",
-  "Rating": "10"
- },
- {
-  "Animal": "Cat",
-  "Name": "Snowy",
-  "Rating": "4"
- },
- {
-  "Animal": "Cat",
-  "Name": "Trisana",
-  "Rating": "7"
- }
+window.data = [
+  {
+    Animal: 'Cat',
+    Name: 'Liza',
+    Rating: '10'
+  },
+  {
+    Animal: 'Dog',
+    Name: 'Boo',
+    Rating: '9'
+  },
+  {
+    Animal: 'Dog',
+    Name: 'Sam',
+    Rating: '10'
+  },
+  {
+    Animal: 'Cat',
+    Name: 'Snowy',
+    Rating: '4'
+  },
+  {
+    Animal: 'Cat',
+    Name: 'Trisana',
+    Rating: '7'
+  }
 ]


### PR DESCRIPTION
## Summary
- Adds a step-by-step table setup guide under docs/table-setup.md.
- Adds a README Quick Start using the bundled local demo instead of relying on the old external demo link.
- Fixes demo support files so lint and browserify verification pass.

## Verification
- npm run lint
- npm run bfy
- served local demo at http://127.0.0.1:8765/test/index.html and confirmed it returns HTTP 200

Closes #24.
Addresses #13.