### PR TITLE
Clarify table setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,19 @@
 
 # sheetsee-tables
 
-Sheetsee,js uses this module to make tables. With this module you can create tables with your spreadsheet data that are sortable, searchable and paginate-able.
+Sheetsee.js uses this module to make tables. With this module you can create tables with your spreadsheet data that are sortable, searchable and paginate-able.
 
 You'll need a placeholder `<div>` in your html, a `<script>` with a [Mustache.js](https://mustache.github.io) template and a `<script>` that tells Sheetsee to build the table.
+
+## Step-by-step table setup
+
+1. Add a placeholder `<div>` for the table.
+2. Add an optional filter `<input>` and a clear link with the `clear` class if you want search.
+3. Add a Mustache template in a `<script>` tag.
+4. Make the template `id` match the table `<div>` id plus `_template`, or pass the custom template id as `templateID`.
+5. Create a `tableOptions` object with your data and element selectors.
+6. Call `Sheetsee.makeTable(tableOptions)`.
+7. Call `Sheetsee.initiateTableFilter(tableOptions)` if you added a filter input.
 
 ## Your HTML Placeholder
 
@@ -85,7 +95,7 @@ If you want to have an input to allow users to search/filter the data in the tab
 
 ```javascript
 <input id="tableFilter" type="text" placeholder="filter by.."></input>
-<a href="#" class=".clear">Clear</a>
+<a href="#" class="clear">Clear</a>
 ```
 
 Then you'll pass your `tableOptions` object into this method:
@@ -99,14 +109,14 @@ Sheetsee.initiateTableFilter(tableOptions)
 _HTML_
 
 ```HTML
-<input id="siteTableFilter" type="text"></input><a href="#" class=".clear">Clear</a>
+<input id="siteTableFilter" type="text"></input><a href="#" class="clear">Clear</a>
 <div id="siteTable"></div>
 ```
 
 _Template_
 
 ```JavaScript
-<script id="tableTemplate" type="text/html">
+<script id="siteTable_template" type="text/html">
     <table>
     <tr><th class="tHeader">City</th><th class="tHeader">Place Name</th><th class="tHeader">Year</th><th class="tHeader">Image</th></tr>
       {{#rows}}
@@ -134,5 +144,5 @@ _JavaScript_
 </script>
 ```
 
-_[View Demo](http://jlord.us/sheetsee.js/demos/demo-table.html)_
-_[Visit Site](http://jlord.us/sheetsee.js)_
+_[View Demo](https://jlord.computer/sheetsee.js/demos/demo-table.html)_
+_[Visit Site](https://jlord.computer/sheetsee.js)_


### PR DESCRIPTION
Summary

- Add a short step-by-step table setup guide
- Fix the README example so the template id matches `templateID`
- Correct the clear button class and update demo links

## Problem

The README example was hard to follow and had a few details that could make a copied example fail: the clear link used `class=".clear"`, the template id did not match the `templateID` option, and the demo links pointed at the old domain.

## Fix

This updates the README with a compact setup checklist and corrects the example markup/options so the documented pieces line up.

## Verification

- [x] Ran `git diff --check`
- [x] Confirmed stale README strings are gone

## Risk

Low. Documentation-only change.